### PR TITLE
Add option to pass compile_kwargs for each player separately

### DIFF
--- a/keras_adversarial/adversarial_model.py
+++ b/keras_adversarial/adversarial_model.py
@@ -55,13 +55,14 @@ class AdversarialModel(Model):
             assert (len(player_models) == self.player_count)
             self.layers = player_models
 
-    def adversarial_compile(self, adversarial_optimizer, player_optimizers, loss, compile_kwargs={},
+    def adversarial_compile(self, adversarial_optimizer, player_optimizers, loss, player_compile_kwargs=[],
                             **kwargs):
         """
         Configures the learning process.
         :param adversarial_optimizer: instance of AdversarialOptimizer
         :param player_optimizers: list of optimizers for each player
         :param loss: loss function or function name
+        :param player_compile_kwargs: list of additional arguments to model compilation for each player
         :param kwargs: additional arguments to function compilation
         :return:
         """
@@ -74,7 +75,8 @@ class AdversarialModel(Model):
         self.optimizer = None
 
         # Build player models
-        for opt, model in zip(self.optimizers, self.layers):
+        for opt, model, compile_kwargs in itertools.zip_longest(
+                self.optimizers, self.layers, player_compile_kwargs, fillvalue={}):
             model.compile(opt, loss=self.loss, **compile_kwargs)
 
         self.train_function = None

--- a/keras_adversarial/adversarial_model.py
+++ b/keras_adversarial/adversarial_model.py
@@ -55,7 +55,7 @@ class AdversarialModel(Model):
             assert (len(player_models) == self.player_count)
             self.layers = player_models
 
-    def adversarial_compile(self, adversarial_optimizer, player_optimizers, loss, player_compile_kwargs=[],
+    def adversarial_compile(self, adversarial_optimizer, player_optimizers, loss, player_compile_kwargs=None,
                             **kwargs):
         """
         Configures the learning process.
@@ -74,9 +74,11 @@ class AdversarialModel(Model):
         self.loss = loss
         self.optimizer = None
 
+        if player_compile_kwargs is None:
+            player_compile_kwargs = [{} for _ in self.layers]
+
         # Build player models
-        for opt, model, compile_kwargs in itertools.zip_longest(
-                self.optimizers, self.layers, player_compile_kwargs, fillvalue={}):
+        for opt, model, compile_kwargs in zip(self.optimizers, self.layers, player_compile_kwargs):
             model.compile(opt, loss=self.loss, **compile_kwargs)
 
         self.train_function = None


### PR DESCRIPTION
Adding this option would be useful to implement models where the discriminator and generator losses have different weights. 

For example, the BEGAN loss function:

![image](https://user-images.githubusercontent.com/6713977/30058562-756d9470-9233-11e7-866f-4660e691aace.png)

could be implemented by passing a symbolic variable `kt` as a loss weight for the discriminator that could be updated in a callback:

 ```
    kt = K.variable(0.0)
    model.adversarial_compile(adversarial_optimizer=AdversarialOptimizerSimultaneous(),
                              player_optimizers=[Adam(1e-4), Adam(1e-4)],
                              player_compile_kwargs=[{}, {'loss_weights': {'yfake': kt}}],
                              loss=custom_loss)
```