### PR TITLE
fix for buggy legacy.get_updates

### DIFF
--- a/keras_adversarial/legacy.py
+++ b/keras_adversarial/legacy.py
@@ -61,6 +61,6 @@ def AveragePooling2D(pool_size, border_mode='valid', **kwargs):
 
 def get_updates(optimizer, params, constraints, loss):
     if keras_2:
-        optimizer.get_updates(params=params, loss=loss)
+        return optimizer.get_updates(params, constraints, loss)
     else:
-        optimizer.get_updates(params, constraints, loss)
+        return optimizer.get_updates(params=params, loss=loss)


### PR DESCRIPTION
The signature of keras-1 and keras-2 methods were swapped and return statements were missing.
